### PR TITLE
update jackson-databind to 2.9.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.4</version>
+      <version>2.9.10.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
update jackson-databind to 2.9.10.5 for some security update.

- https://github.com/advisories/GHSA-j823-4qch-3rgm
- https://github.com/advisories/GHSA-c265-37vj-cwcc
- https://github.com/advisories/GHSA-c2q3-4qrh-fm48
- https://github.com/advisories/GHSA-mc6h-4qgp-37qh

2.9.10.5 is not released at 2020-06-20, so maven build failed now.

after released, test build and merge this.